### PR TITLE
Update CoSMID templates and schema to comply with RFC 9393

### DIFF
--- a/data/coswid/templates/coswid-example.json
+++ b/data/coswid/templates/coswid-example.json
@@ -1,0 +1,17 @@
+{
+  "tag-id": "123e4567-e89b-12d3-a456-426614174000",
+  "tag-version": 0,
+  "software-name": "Example Software",
+  "profile": "http://example.com/cosmid/profile/1",
+  "validity": {
+    "not-before": "2023-01-01T00:00:00Z",
+    "not-after": "2025-01-01T00:00:00Z"
+  },
+  "entity": [
+    {
+      "entity-name": "Example Ltd.",
+      "reg-id": "https://example.com",
+      "role": ["tag-creator"]
+    }
+  ]
+}

--- a/data/coswid/templates/coswid-full.json
+++ b/data/coswid/templates/coswid-full.json
@@ -1,0 +1,26 @@
+{
+  "tag-id": "123e4567-e89b-12d3-a456-426614174000",
+  "tag-version": 0,
+  "software-name": "Example Software",
+  "profile": "http://example.com/cosmid/profile/1",
+  "validity": {
+    "not-before": "2023-01-01T00:00:00Z",
+    "not-after": "2025-01-01T00:00:00Z"
+  },
+  "entity": [
+    {
+      "entity-name": "Example Ltd.",
+      "reg-id": "https://example.com",
+      "role": ["tag-creator"]
+    }
+  ],
+  "link": [
+    {
+      "href": "https://parent.example/rims/ccb3aa85-61b4-40f1-848e-02ad6e8a254b",
+      "thumbprint": {
+        "hash-alg-id": 1,
+        "hash-value": "5Fty9cDAtXLbTY06t+l/No/3TmI0eoJN7LZ6hOUiTXU="
+      }
+    }
+  ]
+}

--- a/data/coswid/templates/coswid-meta-full.json
+++ b/data/coswid/templates/coswid-meta-full.json
@@ -1,0 +1,15 @@
+{
+  "signer": {
+    "entity-name": "Example Ltd signing key",
+    "reg-id": "https://example.com",
+    "role": ["tag-creator"],
+    "thumbprint": {
+      "hash-alg-id": 1, 
+      "hash-value": "dGVzdGhhc2g="  
+    }
+  },
+  "validity": {
+    "not-before": "2023-01-01T00:00:00Z",
+    "not-after": "2025-01-01T00:00:00Z"
+  }
+}

--- a/data/coswid/templates/coswid-meta-mini.json
+++ b/data/coswid/templates/coswid-meta-mini.json
@@ -1,0 +1,6 @@
+{
+  "signer": {
+    "entity-name": "Example Ltd signing key",
+    "role": ["tag-creator"]
+  }
+}

--- a/data/coswid/templates/coswid-schema.json
+++ b/data/coswid/templates/coswid-schema.json
@@ -1,0 +1,410 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "CoSMID Schema",
+  "type": "object",
+  "properties": {
+    "tag-id": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+    },
+    "tag-version": {
+      "type": "integer"
+    },
+    "corpus": {
+      "type": "boolean"
+    },
+    "patch": {
+      "type": "boolean"
+    },
+    "supplemental": {
+      "type": "boolean"
+    },
+    "software-name": {
+      "type": "string"
+    },
+    "software-version": {
+      "type": "string"
+    },
+    "version-scheme": {
+      "type": "string",
+      "enum": ["multipartnumeric", "multipartnumeric-suffix", "alphanumeric", "decimal", "semver"]
+    },
+    "media": {
+      "type": "string"
+    },
+    "software-meta": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "activation-status": {
+            "type": "string"
+          },
+          "channel-type": {
+            "type": "string"
+          },
+          "colloquial-version": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "edition": {
+            "type": "string"
+          },
+          "entitlement-data-required": {
+            "type": "boolean"
+          },
+          "entitlement-key": {
+            "type": "string"
+          },
+          "generator": {
+            "type": ["string", "string"],
+            "pattern": "^[0-9a-fA-F]{32}$"
+          },
+          "persistent-id": {
+            "type": "string"
+          },
+          "product": {
+            "type": "string"
+          },
+          "product-family": {
+            "type": "string"
+          },
+          "revision": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "unspsc-code": {
+            "type": "string"
+          },
+          "unspsc-version": {
+            "type": "string"
+          }
+        },
+        "required": ["activation-status", "channel-type", "colloquial-version", "description", "edition", "entitlement-data-required", "entitlement-key", "generator", "persistent-id", "product", "product-family", "revision", "summary", "unspsc-code", "unspsc-version"]
+      }
+    },
+    "entity": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "entity-name": {
+            "type": "string"
+          },
+          "reg-id": {
+            "type": "string",
+            "format": "uri"
+          },
+          "role": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": ["tag-creator", "software-creator", "aggregator", "distributor", "licensor", "maintainer"]
+            }
+          },
+          "thumbprint": {
+            "type": "object",
+            "properties": {
+              "hash-alg-id": {
+                "type": "integer"
+              },
+              "hash-value": {
+                "type": "string"
+              }
+            },
+            "required": ["hash-alg-id", "hash-value"]
+          }
+        },
+        "required": ["entity-name", "role"]
+      }
+    },
+    "link": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "artifact": {
+            "type": "string"
+          },
+          "href": {
+            "type": "string",
+            "format": "uri"
+          },
+          "media": {
+            "type": "string"
+          },
+          "ownership": {
+            "type": "string",
+            "enum": ["shared", "private", "abandon"]
+          },
+          "rel": {
+            "type": "string",
+            "enum": ["ancestor", "component", "feature", "installationmedia", "packageinstaller", "parent", "patches", "requires", "see-also", "supersedes", "supplemental"]
+          },
+          "media-type": {
+            "type": "string"
+          },
+          "use": {
+            "type": "string",
+            "enum": ["optional", "required", "recommended"]
+          },
+          "thumbprint": {
+            "type": "object",
+            "properties": {
+              "hash-alg-id": {
+                "type": "integer"
+              },
+              "hash-value": {
+                "type": "string"
+              }
+            },
+            "required": ["hash-alg-id", "hash-value"]
+          }
+        },
+        "required": ["href", "rel"]
+      }
+    },
+    "payload": {
+      "type": "object",
+      "properties": {
+        "resource-collection": {
+          "type": "object",
+          "properties": {
+            "directory": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "boolean"
+                  },
+                  "location": {
+                    "type": "string"
+                  },
+                  "fs-name": {
+                    "type": "string"
+                  },
+                  "root": {
+                    "type": "string"
+                  },
+                  "path-elements": {
+                    "type": "object",
+                    "properties": {
+                      "directory": {
+                        "type": "array",
+                        "items": {
+                          "type": "object"
+                        }
+                      },
+                      "file": {
+                        "type": "array",
+                        "items": {
+                          "type": "object"
+                        }
+                      }
+                    }
+                  }
+                },
+                "required": ["fs-name"]
+              }
+            },
+            "file": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "boolean"
+                  },
+                  "location": {
+                    "type": "string"
+                  },
+                  "fs-name": {
+                    "type": "string"
+                  },
+                  "root": {
+                    "type": "string"
+                  },
+                  "size": {
+                    "type": "integer"
+                  },
+                  "file-version": {
+                    "type": "string"
+                  },
+                  "hash": {
+                    "type": "object",
+                    "properties": {
+                      "hash-alg-id": {
+                        "type": "integer"
+                      },
+                      "hash-value": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["hash-alg-id", "hash-value"]
+                  }
+                },
+                "required": ["fs-name"]
+              }
+            },
+            "process": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "process-name": {
+                    "type": "string"
+                  },
+                  "pid": {
+                    "type": "integer"
+                  }
+                },
+                "required": ["process-name"]
+              }
+            },
+            "resource": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "required": ["type"]
+              }
+            }
+          }
+        }
+      }
+    },
+    "evidence": {
+      "type": "object",
+      "properties": {
+        "resource-collection": {
+          "type": "object",
+          "properties": {
+            "directory": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "boolean"
+                  },
+                  "location": {
+                    "type": "string"
+                  },
+                  "fs-name": {
+                    "type": "string"
+                  },
+                  "root": {
+                    "type": "string"
+                  },
+                  "path-elements": {
+                    "type": "object",
+                    "properties": {
+                      "directory": {
+                        "type": "array",
+                        "items": {
+                          "type": "object"
+                        }
+                      },
+                      "file": {
+                        "type": "array",
+                        "items": {
+                          "type": "object"
+                        }
+                      }
+                    }
+                  }
+                },
+                "required": ["fs-name"]
+              }
+            },
+            "file": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "key": {
+                    "type": "boolean"
+                  },
+                  "location": {
+                    "type": "string"
+                  },
+                  "fs-name": {
+                    "type": "string"
+                  },
+                  "root": {
+                    "type": "string"
+                  },
+                  "size": {
+                    "type": "integer"
+                  },
+                  "file-version": {
+                    "type": "string"
+                  },
+                  "hash": {
+                    "type": "object",
+                    "properties": {
+                      "hash-alg-id": {
+                        "type": "integer"
+                      },
+                      "hash-value": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["hash-alg-id", "hash-value"]
+                  }
+                },
+                "required": ["fs-name"]
+              }
+            },
+            "process": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "process-name": {
+                    "type": "string"
+                  },
+                  "pid": {
+                    "type": "integer"
+                  }
+                },
+                "required": ["process-name"]
+              }
+            },
+            "resource": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  }
+                },
+                "required": ["type"]
+              }
+            }
+          }
+        },
+        "date": {
+          "type": "integer"
+        },
+        "device-id": {
+          "type": "string"
+        },
+        "location": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "required": ["tag-id", "tag-version", "software-name", "entity"]
+}


### PR DESCRIPTION
### Pull Request Description

This PR introduces the following changes to the CoSMID templates and schema to ensure compliance with RFC 9393:

1. Added `cosmid-meta-mini.json`:
   - Added `entity-name` and `role` fields to match the `entity-entry` map structure.

2. Added `cosmid-meta-full.json`:
   - Added `entity-name`, `reg-id`, `role`, and `thumbprint` fields to match the `entity-entry` map structure.
   - Retained the `validity` field for metadata.

3. Added `cosmid-example.json`:
   - Added `tag-id`, `tag-version`, `software-name`, `profile`, `validity`, and `entity` fields to match the `concise-swid-tag` map structure.

4. Added `cosmid-full.json`:
   - Added `tag-id`, `tag-version`, `software-name`, `profile`, `validity`, `entity`, and `link` fields to match the `concise-swid-tag` map structure.

5. Added `cosmid-schema.json`:
   - Added properties for `tag-id`, `tag-version`, `corpus`, `patch`, `supplemental`, `software-name`, `software-version`, `version-scheme`, `media`, `software-meta`, `entity`, `link`, `payload`, and `evidence` to match the `concise-swid-tag` map structure.
   - Ensured the schema conforms to the CDDL specification provided in RFC 9393.

fix #19 