### PR TITLE
feat: set kid COSE protected header when signing

### DIFF
--- a/cmd/corimSign.go
+++ b/cmd/corimSign.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 	"github.com/veraison/corim/corim"
@@ -144,6 +145,15 @@ func sign(unsignedCorimFile, keyFile, metaFile string, outputFile, certFile, int
 		Meta:          m,
 	}
 
+	kid, err := keyIDFromJWK(keyJWK)
+	if err != nil {
+		return "", err
+	}
+
+	if kid != "" {
+		s.KeyID = []byte(kid)
+	}
+
 	// Add signing certificate if provided
 	if certFile != nil && *certFile != "" {
 		if certDER, err = afero.ReadFile(fs, *certFile); err != nil {
@@ -188,6 +198,15 @@ func sign(unsignedCorimFile, keyFile, metaFile string, outputFile, certFile, int
 	}
 
 	return signedCorimFile, nil
+}
+
+func keyIDFromJWK(keyJWK []byte) (string, error) {
+	k, err := jwk.ParseKey(keyJWK)
+	if err != nil {
+		return "", err
+	}
+
+	return k.KeyID(), nil
 }
 
 func init() {

--- a/cmd/corimSign_test.go
+++ b/cmd/corimSign_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/veraison/corim/corim"
 )
 
 func Test_CorimSignCmd_unknown_argument(t *testing.T) {
@@ -235,6 +236,13 @@ func Test_CorimSignCmd_ok_with_default_output_file(t *testing.T) {
 
 	_, err = fs.Stat("signed-ok.cbor")
 	assert.NoError(t, err)
+
+	bytes, err := afero.ReadFile(fs, "signed-ok.cbor")
+	assert.NoError(t, err)
+
+	signed, err := corim.UnmarshalAndValidateSignedCorimFromCBOR(bytes)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("1"), signed.KeyID)
 }
 
 func Test_CorimSignCmd_ok_with_custom_output_file(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,14 @@ go 1.23.0
 
 require (
 	github.com/google/uuid v1.3.0
+	github.com/lestrrat-go/jwx/v2 v2.0.21
 	github.com/spf13/afero v1.9.2
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.9.0
 	github.com/stretchr/testify v1.10.0
 	github.com/veraison/apiclient v0.3.1-0.20240807160142-9141ad363e45
-	github.com/veraison/corim v1.1.3-0.20260326144920-25855f5e7afe
+	github.com/veraison/corim v1.1.3-0.20260521083102-6985b7f267bc
 	github.com/veraison/eat v0.0.0-20210331113810-3da8a4dd42ff
 	github.com/veraison/go-cose v1.3.0
 	github.com/veraison/swid v1.1.1-0.20251003121634-fd1f7f1e1897
@@ -31,7 +32,6 @@ require (
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect
 	github.com/lestrrat-go/httprc v1.0.5 // indirect
 	github.com/lestrrat-go/iter v1.0.2 // indirect
-	github.com/lestrrat-go/jwx/v2 v2.0.21 // indirect
 	github.com/lestrrat-go/option v1.0.1 // indirect
 	github.com/magiconair/properties v1.8.5 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -322,8 +322,8 @@ github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/veraison/apiclient v0.3.1-0.20240807160142-9141ad363e45 h1:o+gCzGtusXZOOXuJavzvpraSk8ify4U60Aq9r/4vOho=
 github.com/veraison/apiclient v0.3.1-0.20240807160142-9141ad363e45/go.mod h1:LCXFZ3D/tJ3HLAOHUg8bnAKGvgTl53e1ntwdwjVbQ5A=
-github.com/veraison/corim v1.1.3-0.20260326144920-25855f5e7afe h1:De3llNc+GaDjSnpdJaLkbUO6pMspmLEVZG/U1ky14CU=
-github.com/veraison/corim v1.1.3-0.20260326144920-25855f5e7afe/go.mod h1:96PQ0lk+O9bzutKTDz66G2DaARYUp1BeR06EYwEwSH0=
+github.com/veraison/corim v1.1.3-0.20260521083102-6985b7f267bc h1:cB2BKMTKT8Qf6hs9AMo+26tyt1PltYyug5wb8Ns6RWg=
+github.com/veraison/corim v1.1.3-0.20260521083102-6985b7f267bc/go.mod h1:y1DSE1LC0T6qYsfb7OCo5DrvkCIx8JOkBLDYQ998eho=
 github.com/veraison/eat v0.0.0-20210331113810-3da8a4dd42ff h1:r6I2eJL/z8dp5flsQIKHMeDjyV6UO8If3MaVBLvTjF4=
 github.com/veraison/eat v0.0.0-20210331113810-3da8a4dd42ff/go.mod h1:+kxt8iuFiVvKRs2VQ1Ho7bbAScXAB/kHFFuP5Biw19I=
 github.com/veraison/go-cose v1.3.0 h1:2/H5w8kdSpQJyVtIhx8gmwPJ2uSz1PkyWFx0idbd7rk=


### PR DESCRIPTION
Set the kid (code point 4) protected header of the COSE_Sign1 object to the kid of the signing key (when present).

Addresses https://github.com/veraison/corim/issues/267