### PR TITLE
feat: add int-range support

### DIFF
--- a/cmd/comidCreate_test.go
+++ b/cmd/comidCreate_test.go
@@ -198,6 +198,58 @@ func Test_ComidCreateCmd_template_with_dependency_triples(t *testing.T) {
 	assert.NoError(t, dd[0].Valid())
 }
 
+func Test_ComidCreateCmd_template_with_int_range(t *testing.T) {
+	var err error
+
+	cmd := NewComidCreateCmd()
+
+	fs = afero.NewMemMapFs()
+	err = afero.WriteFile(fs, "comid-with-int-range.json", testIntRangeTemplate, 0644)
+	require.NoError(t, err)
+
+	cmd.SetArgs([]string{"--template=comid-with-int-range.json"})
+	err = cmd.Execute()
+	require.NoError(t, err)
+
+	cborData, err := afero.ReadFile(fs, "comid-with-int-range.cbor")
+	require.NoError(t, err)
+
+	var c comid.Comid
+	err = c.FromCBOR(cborData)
+	require.NoError(t, err)
+	require.NotNil(t, c.Triples.ReferenceValues)
+	require.Len(t, c.Triples.ReferenceValues.Values, 1)
+
+	measurements := c.Triples.ReferenceValues.Values[0].Measurements.Values
+	require.Len(t, measurements, 3)
+
+	// int-range-single: single rawIntInteger value
+	require.NotNil(t, measurements[0].Val.IntRange)
+	require.NoError(t, measurements[0].Val.IntRange.Valid())
+	single, ok := measurements[0].Val.IntRange.Value.(*comid.RawIntInteger)
+	require.True(t, ok)
+	assert.Equal(t, comid.RawIntInteger(42), *single)
+
+	// int-range-bounded: rawIntRange value with both min and max
+	require.NotNil(t, measurements[1].Val.IntRange)
+	require.NoError(t, measurements[1].Val.IntRange.Valid())
+	bounded, ok := measurements[1].Val.IntRange.Value.(*comid.TaggedRawIntRange)
+	require.True(t, ok)
+	require.NotNil(t, bounded.Min)
+	require.NotNil(t, bounded.Max)
+	assert.Equal(t, int64(1), *bounded.Min)
+	assert.Equal(t, int64(10), *bounded.Max)
+
+	// int-range-min-only: rawIntRange value with only min set (max is +inf)
+	require.NotNil(t, measurements[2].Val.IntRange)
+	require.NoError(t, measurements[2].Val.IntRange.Valid())
+	minOnly, ok := measurements[2].Val.IntRange.Value.(*comid.TaggedRawIntRange)
+	require.True(t, ok)
+	require.NotNil(t, minOnly.Min)
+	assert.Equal(t, int64(-5), *minOnly.Min)
+	assert.Nil(t, minOnly.Max)
+}
+
 // Test_ComidCreateCmd_template_with_invalid_dependency_triples checks that creation fails
 // when the template has invalid dependency-triples (e.g. empty trustees).
 func Test_ComidCreateCmd_template_with_invalid_dependency_triples(t *testing.T) {

--- a/cmd/test_vars.go
+++ b/cmd/test_vars.go
@@ -89,4 +89,7 @@ var (
 
 	//go:embed testcases/comid-with-dependency-triples.json
 	testDependencyTriplesTemplate []byte
+
+	//go:embed testcases/comid-with-int-range.json
+	testIntRangeTemplate []byte
 )

--- a/cmd/testcases/cca-platform-refval.json
+++ b/cmd/testcases/cca-platform-refval.json
@@ -42,7 +42,7 @@
               "cryptokeys": [
                 {
                   "type": "bytes",
-                  "value": "01234567890123456789012345678901"
+                  "value": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8="
                 }
               ]
             }

--- a/cmd/testcases/comid-with-int-range.json
+++ b/cmd/testcases/comid-with-int-range.json
@@ -1,0 +1,71 @@
+{
+  "lang": "en-GB",
+  "tag-identity": {
+    "id": "b2c3d4e5-f6a7-8901-bcde-f12345678901",
+    "version": 0
+  },
+  "entities": [
+    {
+      "name": "ACME Ltd.",
+      "regid": "https://acme.example",
+      "roles": ["tagCreator", "creator", "maintainer"]
+    }
+  ],
+  "triples": {
+    "reference-values": [
+      {
+        "environment": {
+          "class": {
+            "id": {
+              "type": "uuid",
+              "value": "DD6661F0-0928-4401-966B-589EA74E3272"
+            }
+          }
+        },
+        "measurements": [
+          {
+            "key": {
+              "type": "string",
+              "value": "int-range-single"
+            },
+            "value": {
+              "int-range": {
+                "type": "rawIntInteger",
+                "value": 42
+              }
+            }
+          },
+          {
+            "key": {
+              "type": "string",
+              "value": "int-range-bounded"
+            },
+            "value": {
+              "int-range": {
+                "type": "rawIntRange",
+                "value": {
+                  "min": 1,
+                  "max": 10
+                }
+              }
+            }
+          },
+          {
+            "key": {
+              "type": "string",
+              "value": "int-range-min-only"
+            },
+            "value": {
+              "int-range": {
+                "type": "rawIntRange",
+                "value": {
+                  "min": -5
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/data/comid/templates/comid-cca-refval.json
+++ b/data/comid/templates/comid-cca-refval.json
@@ -42,7 +42,7 @@
               "cryptokeys": [
                 {
                   "type": "bytes",
-                  "value": "01234567890123456789012345678901"
+                  "value": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8="
                 }
               ]
             }

--- a/data/comid/templates/comid-int-range-refval.json
+++ b/data/comid/templates/comid-int-range-refval.json
@@ -1,0 +1,51 @@
+{
+  "tag-identity": {
+    "id": "9C6BCB1D-8F0E-4C0E-9F3A-0F4B2A9C8E71"
+  },
+  "triples": {
+    "reference-values": [
+      {
+        "environment": {
+          "class": {
+            "id": {
+              "type": "uuid",
+              "value": "DD6661F0-0928-4401-966B-589EA74E3272"
+            },
+            "model": "FMC",
+            "layer": 0,
+            "index": 0
+          }
+        },
+        "measurements": [
+          {
+            "key": {
+              "type": "string",
+              "value": "security-version-number"
+            },
+            "value": {
+              "int-range": {
+                "type": "rawIntInteger",
+                "value": 42
+              }
+            }
+          },
+          {
+            "key": {
+              "type": "string",
+              "value": "acceptable-security-version-numbers"
+            },
+            "value": {
+              "int-range": {
+                "type": "rawIntRange",
+                "value": {
+                  "min": 1,
+                  "max": 10
+                }
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/spf13/viper v1.9.0
 	github.com/stretchr/testify v1.10.0
 	github.com/veraison/apiclient v0.3.1-0.20240807160142-9141ad363e45
-	github.com/veraison/corim v1.1.3-0.20260521083102-6985b7f267bc
+	github.com/veraison/corim v1.1.3-0.20260605091407-c52f1ba4f824
 	github.com/veraison/eat v0.0.0-20210331113810-3da8a4dd42ff
 	github.com/veraison/go-cose v1.3.0
 	github.com/veraison/swid v1.1.1-0.20251003121634-fd1f7f1e1897
@@ -19,7 +19,6 @@ require (
 )
 
 require (
-	fortio.org/safecast v1.0.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.2.0 // indirect
 	github.com/fsnotify/fsnotify v1.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,6 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-fortio.org/safecast v1.0.0 h1:dr3131WPX8iS1pTf76+39WeXbTrerDYLvi9s7Oi3wiY=
-fortio.org/safecast v1.0.0/go.mod h1:xZmcPk3vi4kuUFf+tq4SvnlVdwViqf6ZSZl91Jr9Jdg=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -322,8 +320,8 @@ github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/veraison/apiclient v0.3.1-0.20240807160142-9141ad363e45 h1:o+gCzGtusXZOOXuJavzvpraSk8ify4U60Aq9r/4vOho=
 github.com/veraison/apiclient v0.3.1-0.20240807160142-9141ad363e45/go.mod h1:LCXFZ3D/tJ3HLAOHUg8bnAKGvgTl53e1ntwdwjVbQ5A=
-github.com/veraison/corim v1.1.3-0.20260521083102-6985b7f267bc h1:cB2BKMTKT8Qf6hs9AMo+26tyt1PltYyug5wb8Ns6RWg=
-github.com/veraison/corim v1.1.3-0.20260521083102-6985b7f267bc/go.mod h1:y1DSE1LC0T6qYsfb7OCo5DrvkCIx8JOkBLDYQ998eho=
+github.com/veraison/corim v1.1.3-0.20260605091407-c52f1ba4f824 h1:zTHPFJHRGtU0rU3vK1AxhdB2PXItlPqjmRUJofLDMtg=
+github.com/veraison/corim v1.1.3-0.20260605091407-c52f1ba4f824/go.mod h1:qPBNksTQF5O3PS3yJzEGT7lKVogHgJpbJDq35LgGnc4=
 github.com/veraison/eat v0.0.0-20210331113810-3da8a4dd42ff h1:r6I2eJL/z8dp5flsQIKHMeDjyV6UO8If3MaVBLvTjF4=
 github.com/veraison/eat v0.0.0-20210331113810-3da8a4dd42ff/go.mod h1:+kxt8iuFiVvKRs2VQ1Ho7bbAScXAB/kHFFuP5Biw19I=
 github.com/veraison/go-cose v1.3.0 h1:2/H5w8kdSpQJyVtIhx8gmwPJ2uSz1PkyWFx0idbd7rk=


### PR DESCRIPTION
* Bump veraison/corim to include int-range support (in the process, the "int-range" JSON key is added for free)
* Add example and test templates covering both int-range variants (single integer and inclusive range),
* Fix a pre-existing CCA test fixture which got caught in the version bump (signer-id cryptokey lengths are now enforced).

Fix #57 